### PR TITLE
[2주차] TVING 클론코딩 도전과제

### DIFF
--- a/TvingCloneCoding/TvingCloneCoding.xcodeproj/project.pbxproj
+++ b/TvingCloneCoding/TvingCloneCoding.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C00C0EDE29EA881A002C4D14 /* LoginNicknameBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00C0EDD29EA881A002C4D14 /* LoginNicknameBottomSheetViewController.swift */; };
+		C00C0EE029EA9294002C4D14 /* CGFloat+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00C0EDF29EA9294002C4D14 /* CGFloat+.swift */; };
+		C00C0EE329EA9302002C4D14 /* TvingBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00C0EE229EA9302002C4D14 /* TvingBottomSheet.swift */; };
+		C00C0EE529EAA016002C4D14 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00C0EE429EAA016002C4D14 /* UIViewController+.swift */; };
 		C0E462C129E6F646005CCEC6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E462C029E6F646005CCEC6 /* AppDelegate.swift */; };
 		C0E462C329E6F646005CCEC6 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E462C229E6F646005CCEC6 /* SceneDelegate.swift */; };
 		C0E462C529E6F646005CCEC6 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E462C429E6F646005CCEC6 /* LoginViewController.swift */; };
@@ -40,6 +44,10 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		C00C0EDD29EA881A002C4D14 /* LoginNicknameBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginNicknameBottomSheetViewController.swift; sourceTree = "<group>"; };
+		C00C0EDF29EA9294002C4D14 /* CGFloat+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGFloat+.swift"; sourceTree = "<group>"; };
+		C00C0EE229EA9302002C4D14 /* TvingBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TvingBottomSheet.swift; sourceTree = "<group>"; };
+		C00C0EE429EAA016002C4D14 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		C0E462BD29E6F646005CCEC6 /* TvingCloneCoding.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TvingCloneCoding.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0E462C029E6F646005CCEC6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C0E462C229E6F646005CCEC6 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -85,6 +93,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		C00C0EE129EA92E9002C4D14 /* BottomSheet */ = {
+			isa = PBXGroup;
+			children = (
+				C00C0EE229EA9302002C4D14 /* TvingBottomSheet.swift */,
+			);
+			path = BottomSheet;
+			sourceTree = "<group>";
+		};
 		C0E462B429E6F646005CCEC6 = {
 			isa = PBXGroup;
 			children = (
@@ -171,6 +187,8 @@
 				C0E462FA29E70400005CCEC6 /* UITextField+.swift */,
 				C0E462FC29E70418005CCEC6 /* UIbutton+.swift */,
 				C0E4630C29E7D1AC005CCEC6 /* UIImage+.swift */,
+				C00C0EDF29EA9294002C4D14 /* CGFloat+.swift */,
+				C00C0EE429EAA016002C4D14 /* UIViewController+.swift */,
 			);
 			path = Extenstions;
 			sourceTree = "<group>";
@@ -198,6 +216,7 @@
 		C0E4630329E7CE69005CCEC6 /* Utility */ = {
 			isa = PBXGroup;
 			children = (
+				C00C0EE129EA92E9002C4D14 /* BottomSheet */,
 				C0E4632C29E814D7005CCEC6 /* ImageView */,
 				C0E4632729E80EF2005CCEC6 /* Label */,
 				C0E4632429E80D00005CCEC6 /* Button */,
@@ -262,6 +281,7 @@
 			children = (
 				C0E4632229E8081C005CCEC6 /* LoginCompletedViewController.swift */,
 				C0E462C429E6F646005CCEC6 /* LoginViewController.swift */,
+				C00C0EDD29EA881A002C4D14 /* LoginNicknameBottomSheetViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -367,8 +387,10 @@
 			files = (
 				C0E4630829E7CF22005CCEC6 /* TvingTextField.swift in Sources */,
 				C0E462EC29E6FB2F005CCEC6 /* Font.swift in Sources */,
+				C00C0EE529EAA016002C4D14 /* UIViewController+.swift in Sources */,
 				C0E462C529E6F646005CCEC6 /* LoginViewController.swift in Sources */,
 				C0E4632129E80056005CCEC6 /* LoginSettingView.swift in Sources */,
+				C00C0EE029EA9294002C4D14 /* CGFloat+.swift in Sources */,
 				C0E462F929E703D9005CCEC6 /* String+.swift in Sources */,
 				C0E4632E29E814E3005CCEC6 /* TvingImageView.swift in Sources */,
 				C0E462FB29E70400005CCEC6 /* UITextField+.swift in Sources */,
@@ -378,6 +400,8 @@
 				C0E462C129E6F646005CCEC6 /* AppDelegate.swift in Sources */,
 				C0E4630B29E7D087005CCEC6 /* Constant.swift in Sources */,
 				C0E4632629E80D28005CCEC6 /* TvingButton.swift in Sources */,
+				C00C0EE329EA9302002C4D14 /* TvingBottomSheet.swift in Sources */,
+				C00C0EDE29EA881A002C4D14 /* LoginNicknameBottomSheetViewController.swift in Sources */,
 				C0E462C329E6F646005CCEC6 /* SceneDelegate.swift in Sources */,
 				C0E462F529E7037A005CCEC6 /* CGColor+.swift in Sources */,
 				C0E462F729E703BC005CCEC6 /* UIView+.swift in Sources */,

--- a/TvingCloneCoding/TvingCloneCoding/Source/Presenter/Login/ViewController/LoginCompletedViewController.swift
+++ b/TvingCloneCoding/TvingCloneCoding/Source/Presenter/Login/ViewController/LoginCompletedViewController.swift
@@ -25,7 +25,7 @@ final class LoginCompletedViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setUI()
-        hierarchy()
+        setHierarchy()
         setLayout()
         setButtonTarget()
     }
@@ -38,7 +38,7 @@ private extension LoginCompletedViewController {
         view.backgroundColor = .designSystem(.black)
     }
     
-    func hierarchy() {
+    func setHierarchy() {
         view.addSubviews(tvingMainImageView, userNicNameLabel, presentMainViewControllerButton)
     }
 

--- a/TvingCloneCoding/TvingCloneCoding/Source/Presenter/Login/ViewController/LoginCompletedViewController.swift
+++ b/TvingCloneCoding/TvingCloneCoding/Source/Presenter/Login/ViewController/LoginCompletedViewController.swift
@@ -11,39 +11,44 @@ import SnapKit
 
 final class LoginCompletedViewController: UIViewController {
     
-    var userEmail: String? {
+    var userNickName: String? {
         didSet {
-            guard let userEmail else { return }
-            userEmailLabel.text = userEmail + "님" + "\n반가워요"
+            guard let userNickName else { return }
+            userNicNameLabel.text = userNickName + "님" + "\n반가워요"
         }
     }
 
     private lazy var tvingMainImageView = TvingImageView(imageName: Constant.ImageName.tvingMainImage, contentMode: .scaleAspectFill)
-    private lazy var userEmailLabel = TvingLabel(fontWeight: ._700, fontSize: ._23, fontColor: .grayD6D6D6)
+    private lazy var userNicNameLabel = TvingLabel(fontWeight: ._700, fontSize: ._23, fontColor: .grayD6D6D6)
     private lazy var presentMainViewControllerButton = TvingRectangleButton(title: Constant.ButtonTitle.presentMainButtonTitle, buttonType: .active)
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .designSystem(.black)
-        hierarchy()
         setUI()
+        hierarchy()
+        setLayout()
         setButtonTarget()
     }
 
 }
 
 private extension LoginCompletedViewController {
-    func hierarchy() {
-        view.addSubviews(tvingMainImageView, userEmailLabel, presentMainViewControllerButton)
-    }
     
     func setUI() {
+        view.backgroundColor = .designSystem(.black)
+    }
+    
+    func hierarchy() {
+        view.addSubviews(tvingMainImageView, userNicNameLabel, presentMainViewControllerButton)
+    }
+
+    func setLayout() {
         tvingMainImageView.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide)
             make.leading.trailing.equalToSuperview()
         }
         
-        userEmailLabel.snp.makeConstraints { make in
+        userNicNameLabel.snp.makeConstraints { make in
             make.top.equalTo(tvingMainImageView.snp.bottom).offset(67)
             make.leading.trailing.equalToSuperview().inset(75)
         }

--- a/TvingCloneCoding/TvingCloneCoding/Source/Presenter/Login/ViewController/LoginNicknameBottomSheetViewController.swift
+++ b/TvingCloneCoding/TvingCloneCoding/Source/Presenter/Login/ViewController/LoginNicknameBottomSheetViewController.swift
@@ -1,0 +1,178 @@
+//
+//  LoginNicknameBottomSheetViewController.swift
+//  TvingCloneCoding
+//
+//  Created by uiskim on 2023/04/15.
+//
+
+import UIKit
+
+import SnapKit
+
+protocol PassingNicknameDataProtocol: AnyObject {
+    func sendNickname(_ nickName: String)
+}
+
+final class LoginNicknameBottomSheetViewController: UIViewController {
+    
+    weak var delegate: PassingNicknameDataProtocol?
+    
+    private let bottomSheetHeightPercentage: CGFloat
+    
+    private let backgroundView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .designSystem(.black)
+        view.alpha = 0.0
+        return view
+    }()
+    
+    private let clearView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .clear
+        return view
+    }()
+    
+    private let handleView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        view.layer.cornerRadius = 7/2
+        return view
+    }()
+    
+    
+    private let bottomSheetView = TvingBottomSheet(color: .designSystem(.white))
+    private let nicknameLabel = TvingLabel(title: "닉네임을 입력해주세요", fontWeight: ._500, fontSize: ._23, fontColor: .black)
+    private let nicknameTextField = TvingTextField(textFieldType: .normal, sidePadding: 20)
+    private let saveNicknameButton = TvingRectangleButton(title: "저장하기", buttonType: .nonActive)
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        nicknameTextField.delegate = self
+        hierarchy()
+        setTapGesture()
+        setAddTarget()
+        setLayout()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        showBottomSheet()
+    }
+    
+    init(bottomSheetHeightPercentage: CGFloat) {
+        self.bottomSheetHeightPercentage = bottomSheetHeightPercentage
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension LoginNicknameBottomSheetViewController: UITextFieldDelegate {
+    func textFieldDidChangeSelection(_ textField: UITextField) {
+        guard let text = textField.text else { return }
+        saveNicknameButton.makeActiveTypeButton(activeType: text.isNotEmpty ? .active : .nonActive)
+    }
+}
+
+extension LoginNicknameBottomSheetViewController {
+    
+    
+    private func hierarchy() {
+        view.addSubviews(backgroundView, bottomSheetView, clearView)
+        clearView.addSubview(handleView)
+        bottomSheetView.addSubviews(nicknameLabel, nicknameTextField, saveNicknameButton)
+    }
+
+    
+    private func setTapGesture() {
+        let backgroundTap = UITapGestureRecognizer(target: self, action: #selector(backgroundViewTapped(_:)))
+        backgroundView.addGestureRecognizer(backgroundTap)
+        backgroundView.isUserInteractionEnabled = true
+
+    }
+    
+    private func setAddTarget() {
+        saveNicknameButton.addTarget(self, action: #selector(saveNicknameButtonTapped), for: .touchUpInside)
+    }
+    
+    private func setLayout() {
+        backgroundView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        handleView.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.centerX.equalToSuperview()
+            make.width.equalTo(56)
+            make.height.equalTo(7)
+        }
+        clearView.snp.makeConstraints { make in
+            make.bottom.equalTo(bottomSheetView.snp.top)
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(22)
+        }
+        
+        bottomSheetView.clipsToBounds = true
+        bottomSheetView.snp.makeConstraints { make in
+            make.leading.trailing.equalToSuperview()
+            make.top.equalTo(view.snp.bottom)
+            make.bottom.equalToSuperview().inset(Constant.Screen.height*(-bottomSheetHeightPercentage.makePercentage))
+        }
+        
+        nicknameLabel.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(50)
+            make.leading.equalToSuperview().inset(20)
+        }
+        
+        nicknameTextField.snp.makeConstraints { make in
+            make.top.equalTo(nicknameLabel.snp.bottom).offset(21)
+            make.leading.trailing.equalToSuperview().inset(20)
+            make.height.equalTo(52)
+        }
+        
+        saveNicknameButton.snp.makeConstraints { make in
+            make.bottom.equalToSuperview().inset(30)
+            make.leading.trailing.equalToSuperview().inset(20)
+            make.height.equalTo(52)
+        }
+        
+    }
+    
+    private func hideButtonSheetAndDismissViewController() {
+        UIView.animate(withDuration: 0.25) {
+            self.resetPosition(views: self.bottomSheetView, self.clearView)
+            self.backgroundView.alpha = 0
+        } completion: { _ in
+            if self.presentationController != nil {
+                self.dismiss(animated: true)
+            }
+        }
+    }
+    
+    private func showBottomSheet() {
+        let moveDistance = -self.bottomSheetView.bounds.height
+        UIView.animate(withDuration: 0.25) {
+            self.moveVerticalPosition(views: self.bottomSheetView, self.clearView, distance: moveDistance)
+            self.backgroundView.alpha = 0.7
+        }
+    }
+    
+    @objc func backgroundViewTapped(_ tapRecongnizer: UITapGestureRecognizer) {
+        hideButtonSheetAndDismissViewController()
+    }
+    
+    @objc func saveNicknameButtonTapped() {
+        UIView.animate(withDuration: 0.15) {
+            self.resetPosition(views: self.bottomSheetView, self.clearView)
+            self.backgroundView.alpha = 0
+        } completion: { _ in
+            if self.presentationController != nil {
+                guard let nickName = self.nicknameTextField.text else { return }
+                self.delegate?.sendNickname(nickName)
+                self.dismiss(animated: true)
+            }
+        }
+    }
+    
+}

--- a/TvingCloneCoding/TvingCloneCoding/Source/Presenter/Login/ViewController/LoginNicknameBottomSheetViewController.swift
+++ b/TvingCloneCoding/TvingCloneCoding/Source/Presenter/Login/ViewController/LoginNicknameBottomSheetViewController.swift
@@ -72,7 +72,12 @@ final class LoginNicknameBottomSheetViewController: UIViewController {
 extension LoginNicknameBottomSheetViewController: UITextFieldDelegate {
     func textFieldDidChangeSelection(_ textField: UITextField) {
         guard let text = textField.text else { return }
+        nicknameTextField.showClearButton = text.isNotEmpty ? false : true
         saveNicknameButton.makeActiveTypeButton(activeType: text.isNotEmpty ? .active : .nonActive)
+    }
+    
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        textField.rightViewMode = .always
     }
 }
 

--- a/TvingCloneCoding/TvingCloneCoding/Source/Presenter/Login/ViewController/LoginNicknameBottomSheetViewController.swift
+++ b/TvingCloneCoding/TvingCloneCoding/Source/Presenter/Login/ViewController/LoginNicknameBottomSheetViewController.swift
@@ -48,7 +48,7 @@ final class LoginNicknameBottomSheetViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         nicknameTextField.delegate = self
-        hierarchy()
+        setHierarchy()
         setTapGesture()
         setAddTarget()
         setLayout()
@@ -79,7 +79,7 @@ extension LoginNicknameBottomSheetViewController: UITextFieldDelegate {
 extension LoginNicknameBottomSheetViewController {
     
     
-    private func hierarchy() {
+    private func setHierarchy() {
         view.addSubviews(backgroundView, bottomSheetView, clearView)
         clearView.addSubview(handleView)
         bottomSheetView.addSubviews(nicknameLabel, nicknameTextField, saveNicknameButton)
@@ -113,7 +113,6 @@ extension LoginNicknameBottomSheetViewController {
             make.height.equalTo(22)
         }
         
-        bottomSheetView.clipsToBounds = true
         bottomSheetView.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview()
             make.height.equalTo(bottomSheetHeight)
@@ -138,7 +137,7 @@ extension LoginNicknameBottomSheetViewController {
         }
     }
     
-    private func hideButtonSheetAndDismissViewController() {
+    private func hideBottomSheetAndDismissViewController() {
         bottomSheetView.snp.updateConstraints { $0.bottom.equalToSuperview().inset(-bottomSheetHeight) }
         UIView.animate(withDuration: 0.25) {
             self.backgroundView.alpha = 0
@@ -159,7 +158,7 @@ extension LoginNicknameBottomSheetViewController {
     }
     
     @objc func backgroundViewTapped(_ tapRecongnizer: UITapGestureRecognizer) {
-        hideButtonSheetAndDismissViewController()
+        hideBottomSheetAndDismissViewController()
     }
     
     @objc func saveNicknameButtonTapped() {

--- a/TvingCloneCoding/TvingCloneCoding/Source/Presenter/Login/ViewController/LoginNicknameBottomSheetViewController.swift
+++ b/TvingCloneCoding/TvingCloneCoding/Source/Presenter/Login/ViewController/LoginNicknameBottomSheetViewController.swift
@@ -17,7 +17,7 @@ final class LoginNicknameBottomSheetViewController: UIViewController {
     
     weak var delegate: PassingNicknameDataProtocol?
     
-    private let bottomSheetHeightPercentage: CGFloat
+    private let bottomSheetHeight: CGFloat
     
     private let backgroundView: UIView = {
         let view = UIView()
@@ -60,7 +60,7 @@ final class LoginNicknameBottomSheetViewController: UIViewController {
     }
     
     init(bottomSheetHeightPercentage: CGFloat) {
-        self.bottomSheetHeightPercentage = bottomSheetHeightPercentage
+        self.bottomSheetHeight = bottomSheetHeightPercentage.makePercentage * Constant.Screen.height
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -116,8 +116,8 @@ extension LoginNicknameBottomSheetViewController {
         bottomSheetView.clipsToBounds = true
         bottomSheetView.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview()
-            make.top.equalTo(view.snp.bottom)
-            make.bottom.equalToSuperview().inset(Constant.Screen.height*(-bottomSheetHeightPercentage.makePercentage))
+            make.height.equalTo(bottomSheetHeight)
+            make.bottom.equalToSuperview().inset(-bottomSheetHeight)
         }
         
         nicknameLabel.snp.makeConstraints { make in
@@ -136,13 +136,13 @@ extension LoginNicknameBottomSheetViewController {
             make.leading.trailing.equalToSuperview().inset(20)
             make.height.equalTo(52)
         }
-        
     }
     
     private func hideButtonSheetAndDismissViewController() {
+        bottomSheetView.snp.updateConstraints { $0.bottom.equalToSuperview().inset(-bottomSheetHeight) }
         UIView.animate(withDuration: 0.25) {
-            self.resetPosition(views: self.bottomSheetView, self.clearView)
             self.backgroundView.alpha = 0
+            self.view.layoutIfNeeded()
         } completion: { _ in
             if self.presentationController != nil {
                 self.dismiss(animated: true)
@@ -151,10 +151,10 @@ extension LoginNicknameBottomSheetViewController {
     }
     
     private func showBottomSheet() {
-        let moveDistance = -self.bottomSheetView.bounds.height
+        bottomSheetView.snp.updateConstraints { $0.bottom.equalToSuperview() }
         UIView.animate(withDuration: 0.25) {
-            self.moveVerticalPosition(views: self.bottomSheetView, self.clearView, distance: moveDistance)
             self.backgroundView.alpha = 0.7
+            self.view.layoutIfNeeded()
         }
     }
     
@@ -163,9 +163,10 @@ extension LoginNicknameBottomSheetViewController {
     }
     
     @objc func saveNicknameButtonTapped() {
+        bottomSheetView.snp.updateConstraints { $0.bottom.equalToSuperview().inset(-bottomSheetHeight) }
         UIView.animate(withDuration: 0.15) {
-            self.resetPosition(views: self.bottomSheetView, self.clearView)
             self.backgroundView.alpha = 0
+            self.view.layoutIfNeeded()
         } completion: { _ in
             if self.presentationController != nil {
                 guard let nickName = self.nicknameTextField.text else { return }

--- a/TvingCloneCoding/TvingCloneCoding/Source/Presenter/Login/ViewController/LoginNicknameBottomSheetViewController.swift
+++ b/TvingCloneCoding/TvingCloneCoding/Source/Presenter/Login/ViewController/LoginNicknameBottomSheetViewController.swift
@@ -138,11 +138,7 @@ extension LoginNicknameBottomSheetViewController {
     }
     
     private func hideBottomSheetAndDismissViewController() {
-        bottomSheetView.snp.updateConstraints { $0.bottom.equalToSuperview().inset(-bottomSheetHeight) }
-        UIView.animate(withDuration: 0.25) {
-            self.backgroundView.alpha = 0
-            self.view.layoutIfNeeded()
-        } completion: { _ in
+        hideBottomSheet(bottomSheet: bottomSheetView) {
             if self.presentationController != nil {
                 self.dismiss(animated: true)
             }
@@ -162,16 +158,22 @@ extension LoginNicknameBottomSheetViewController {
     }
     
     @objc func saveNicknameButtonTapped() {
-        bottomSheetView.snp.updateConstraints { $0.bottom.equalToSuperview().inset(-bottomSheetHeight) }
-        UIView.animate(withDuration: 0.15) {
-            self.backgroundView.alpha = 0
-            self.view.layoutIfNeeded()
-        } completion: { _ in
+        hideBottomSheet(bottomSheet: bottomSheetView) {
             if self.presentationController != nil {
                 guard let nickName = self.nicknameTextField.text else { return }
                 self.delegate?.sendNickname(nickName)
                 self.dismiss(animated: true)
             }
+        }
+    }
+    
+    private func hideBottomSheet<T: TvingBottomSheet>(bottomSheet: T, duration: CGFloat = 0.25, completionHandler: @escaping () -> Void) {
+        bottomSheet.snp.updateConstraints { $0.bottom.equalToSuperview().inset(-bottomSheet.bounds.height) }
+        UIView.animate(withDuration: duration) {
+            self.backgroundView.alpha = 0
+            self.view.layoutIfNeeded()
+        } completion: { _ in
+            completionHandler()
         }
     }
     

--- a/TvingCloneCoding/TvingCloneCoding/Source/Presenter/Login/ViewController/LoginViewController.swift
+++ b/TvingCloneCoding/TvingCloneCoding/Source/Presenter/Login/ViewController/LoginViewController.swift
@@ -40,16 +40,26 @@ extension LoginViewController: UITextFieldDelegate {
         guard let text = textField.text, let tvingTextField = textField as? TvingTextField else { return }
         guard let emailText = emailTextField.text, let passwordText = passwordTextField.text else { return }
         
-        tvingTextField.clearButtonClicked = text.isNotEmpty ? false : true
-        loginButton.makeActiveTypeButton(activeType: emailText.checkEmail && passwordText.checkPassword && ((nickName?.isNotEmpty) != nil) ? .active : .nonActive)
+        tvingTextField.showClearButton = text.isNotEmpty ? false : true
+        loginButton.makeActiveTypeButton(activeType: checkUserInputIsValid(emailText)(passwordText)(nickName) ? .active : .nonActive)
     }
+    
+    private func checkUserInputIsValid(_ email: String) -> (_ password: String) -> (_ nickName: String?) -> Bool {
+        return { password in
+            return { nickName in
+                return email.checkEmail && password.checkPassword && ((nickName?.isNotEmpty) != nil)
+            }
+        }
+    }
+    
+    
     
     func textFieldDidBeginEditing(_ textField: UITextField) {
         guard let text = textField.text, let tvingTextField = textField as? TvingTextField else { return }
         
         textField.makeTextFieldFocused()
         tvingTextField.rightViewMode = .always
-        tvingTextField.clearButtonClicked = text.isEmpty ? true : false
+        tvingTextField.showClearButton = text.isEmpty ? true : false
     }
     
     func textFieldDidEndEditing(_ textField: UITextField) {

--- a/TvingCloneCoding/TvingCloneCoding/Source/Presenter/Login/ViewController/LoginViewController.swift
+++ b/TvingCloneCoding/TvingCloneCoding/Source/Presenter/Login/ViewController/LoginViewController.swift
@@ -11,6 +11,8 @@ import SnapKit
 
 final class LoginViewController: UIViewController {
     
+    private var nickName: String?
+    
     private let loginTitleLabel = TvingLabel(title: "TVING ID 로그인", fontWeight: ._500, fontSize: ._23, fontColor: .white)
     private let emailTextField = TvingTextField(textFieldType: .email, sidePadding: 20)
     private let passwordTextField = TvingTextField(textFieldType: .password, sidePadding: 20)
@@ -39,7 +41,7 @@ extension LoginViewController: UITextFieldDelegate {
         guard let emailText = emailTextField.text, let passwordText = passwordTextField.text else { return }
         
         tvingTextField.clearButtonClicked = text.isNotEmpty ? false : true
-        loginButton.makeActiveTypeButton(activeType: emailText.checkEmail && passwordText.checkPassword ? .active : .nonActive)
+        loginButton.makeActiveTypeButton(activeType: emailText.checkEmail && passwordText.checkPassword && ((nickName?.isNotEmpty) != nil) ? .active : .nonActive)
     }
     
     func textFieldDidBeginEditing(_ textField: UITextField) {
@@ -114,15 +116,26 @@ private extension LoginViewController {
     }
     
     @objc func loginButtonTapped(_ sender: UIButton) {
-        print("로그인버튼이 눌렸습니다")
         let loginCompletedViewController = LoginCompletedViewController()
         loginCompletedViewController.modalPresentationStyle = .fullScreen
-        loginCompletedViewController.userEmail = emailTextField.text
+        loginCompletedViewController.userNickName = nickName
         self.present(loginCompletedViewController, animated: true)
     }
     
     @objc func makeNicknameButtonTapped(_ sender: UIButton) {
-        print("닉네임만들러가기 버튼이 눌렸습니다")
+        let bottomSheetVC = LoginNicknameBottomSheetViewController(bottomSheetHeightPercentage: 50)
+        bottomSheetVC.delegate = self
+        bottomSheetVC.modalPresentationStyle = .overFullScreen
+        self.present(bottomSheetVC, animated: false)
     }
+}
+
+extension LoginViewController: PassingNicknameDataProtocol {
+    func sendNickname(_ nickName: String) {
+        guard let emailText = emailTextField.text, let passwordText = passwordTextField.text else { return }
+        self.nickName = nickName
+        loginButton.makeActiveTypeButton(activeType: emailText.checkEmail && passwordText.checkPassword ? .active : .nonActive)
+    }
+
 }
 

--- a/TvingCloneCoding/TvingCloneCoding/Source/Presenter/Login/ViewController/LoginViewController.swift
+++ b/TvingCloneCoding/TvingCloneCoding/Source/Presenter/Login/ViewController/LoginViewController.swift
@@ -22,7 +22,7 @@ final class LoginViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .designSystem(.black)
-        hierarchy()
+        setHierarchy()
         setUI()
         setNavigationBar()
         setDelegate()
@@ -93,7 +93,7 @@ private extension LoginViewController {
         loginButton.addTarget(self, action: #selector(loginButtonTapped(_:)), for: .touchUpInside)
     }
     
-    func hierarchy() {
+    func setHierarchy() {
         view.addSubviews(loginTitleLabel, emailTextField, passwordTextField, loginButton, loginSettingView)
     }
     

--- a/TvingCloneCoding/TvingCloneCoding/Source/Utility/BottomSheet/TvingBottomSheet.swift
+++ b/TvingCloneCoding/TvingCloneCoding/Source/Utility/BottomSheet/TvingBottomSheet.swift
@@ -1,0 +1,23 @@
+//
+//  TvingBottomSheet.swift
+//  TvingCloneCoding
+//
+//  Created by uiskim on 2023/04/15.
+//
+
+import UIKit
+
+final class TvingBottomSheet: UIView {
+
+    init(color: UIColor?, cornerRadius: CGFloat = 26) {
+        super.init(frame: .zero)
+        self.backgroundColor = color
+        self.layer.cornerRadius = cornerRadius
+        self.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        self.clipsToBounds = true
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/TvingCloneCoding/TvingCloneCoding/Source/Utility/Constants/Constant.swift
+++ b/TvingCloneCoding/TvingCloneCoding/Source/Utility/Constants/Constant.swift
@@ -20,4 +20,9 @@ struct Constant {
         static let loginButtonTitle = "로그인하기"
         static let presentMainButtonTitle = "메인으로"
     }
+    
+    struct Screen {
+        static let width = UIScreen.main.bounds.width
+        static let height = UIScreen.main.bounds.height
+    }
 }

--- a/TvingCloneCoding/TvingCloneCoding/Source/Utility/Extenstions/CGFloat+.swift
+++ b/TvingCloneCoding/TvingCloneCoding/Source/Utility/Extenstions/CGFloat+.swift
@@ -1,0 +1,14 @@
+//
+//  CGFloat+.swift
+//  TvingCloneCoding
+//
+//  Created by uiskim on 2023/04/15.
+//
+
+import UIKit
+
+extension CGFloat {
+    var makePercentage: CGFloat {
+        return self/100
+    }
+}

--- a/TvingCloneCoding/TvingCloneCoding/Source/Utility/Extenstions/UIViewController+.swift
+++ b/TvingCloneCoding/TvingCloneCoding/Source/Utility/Extenstions/UIViewController+.swift
@@ -8,14 +8,5 @@
 import UIKit
 
 
-extension UIViewController {
-    
-    func moveVerticalPosition(views: UIView..., distance: CGFloat) {
-        views.forEach { $0.transform = CGAffineTransform(translationX: 0, y: distance) }
-    }
-    
-    func resetPosition(views: UIView...) {
-        views.forEach { $0.transform = .identity }
-    }
-}
+extension UIViewController { }
 

--- a/TvingCloneCoding/TvingCloneCoding/Source/Utility/Extenstions/UIViewController+.swift
+++ b/TvingCloneCoding/TvingCloneCoding/Source/Utility/Extenstions/UIViewController+.swift
@@ -1,0 +1,21 @@
+//
+//  UIViewController+.swift
+//  TvingCloneCoding
+//
+//  Created by uiskim on 2023/04/15.
+//
+
+import UIKit
+
+
+extension UIViewController {
+    
+    func moveVerticalPosition(views: UIView..., distance: CGFloat) {
+        views.forEach { $0.transform = CGAffineTransform(translationX: 0, y: distance) }
+    }
+    
+    func resetPosition(views: UIView...) {
+        views.forEach { $0.transform = .identity }
+    }
+}
+

--- a/TvingCloneCoding/TvingCloneCoding/Source/Utility/Extenstions/UIbutton+.swift
+++ b/TvingCloneCoding/TvingCloneCoding/Source/Utility/Extenstions/UIbutton+.swift
@@ -55,8 +55,8 @@ extension UIButton {
     }
     
     private func setBorderInButton(isActive: Bool) {
+        self.layer.borderWidth = isActive ? 0 : 1
         if !isActive {
-            self.layer.borderWidth = 1
             self.layer.borderColor = .designSystem(.gray2E2E2E)
         }
     }

--- a/TvingCloneCoding/TvingCloneCoding/Source/Utility/Extenstions/UIbutton+.swift
+++ b/TvingCloneCoding/TvingCloneCoding/Source/Utility/Extenstions/UIbutton+.swift
@@ -9,6 +9,7 @@ import UIKit
 
 extension UIButton {
     
+    @frozen
     enum ButtonActive {
         case active
         case nonActive
@@ -75,6 +76,8 @@ extension UIButton {
 }
 
 extension UIButton {
+    
+    @frozen
     enum LoginButtonImageType {
         case clear
         case hidePassword

--- a/TvingCloneCoding/TvingCloneCoding/Source/Utility/TextField/TvingTextField.swift
+++ b/TvingCloneCoding/TvingCloneCoding/Source/Utility/TextField/TvingTextField.swift
@@ -19,9 +19,9 @@ final class TvingTextField: UITextField {
     private var textFieldType: TextFieldType
     private let sidePadding: Int
     
-    var clearButtonClicked: Bool = false {
+    var showClearButton: Bool = false {
         didSet {
-            clearButton.isHidden = clearButtonClicked
+            clearButton.isHidden = showClearButton
         }
     }
     

--- a/TvingCloneCoding/TvingCloneCoding/Source/Utility/TextField/TvingTextField.swift
+++ b/TvingCloneCoding/TvingCloneCoding/Source/Utility/TextField/TvingTextField.swift
@@ -13,6 +13,26 @@ final class TvingTextField: UITextField {
         case email
         case password
         case normal
+        
+        var placeHolder: String {
+            switch self {
+            case .email:
+                return "아이디"
+            case .password:
+                return "비밀번호"
+            case .normal:
+                return "닉네임"
+            }
+        }
+        
+        var isSecureTextEntry: Bool {
+            switch self {
+            case .email, .normal:
+                return false
+            case .password:
+                return true
+            }
+        }
     }
     
     private let righthButtonView = UIView()
@@ -62,19 +82,14 @@ final class TvingTextField: UITextField {
         self.font = .pretendard(weight: ._600, size: ._15)
         self.textColor = .designSystem(.gray9C9C9C)
         
+        self.setLoginPlaceholder(placeholder: textFieldType.placeHolder)
+        self.isSecureTextEntry = textFieldType.isSecureTextEntry
+        
         switch textFieldType {
-        case .email:
-            self.setLoginPlaceholder(placeholder: "아이디")
-            isSecureTextEntry = false
+        case .email, .normal:
             rightView = righthButtonView.addButtonsInTextfield(views: [clearButton], padding: sidePadding)
         case .password:
-            self.setLoginPlaceholder(placeholder: "비밀번호")
-            isSecureTextEntry = true
             rightView = righthButtonView.addButtonsInTextfield(views: [clearButton, securityButton], padding: sidePadding)
-        case .normal:
-            self.setLoginPlaceholder(placeholder: "닉네임")
-            isSecureTextEntry = false
-            rightView = righthButtonView.addButtonsInTextfield(views: [clearButton], padding: sidePadding)
         }
     }
     

--- a/TvingCloneCoding/TvingCloneCoding/Source/Utility/TextField/TvingTextField.swift
+++ b/TvingCloneCoding/TvingCloneCoding/Source/Utility/TextField/TvingTextField.swift
@@ -12,6 +12,7 @@ final class TvingTextField: UITextField {
     enum TextFieldType {
         case email
         case password
+        case normal
     }
     
     private let righthButtonView = UIView()
@@ -70,6 +71,10 @@ final class TvingTextField: UITextField {
             self.setLoginPlaceholder(placeholder: "비밀번호")
             isSecureTextEntry = true
             rightView = righthButtonView.addButtonsInTextfield(views: [clearButton, securityButton], padding: sidePadding)
+        case .normal:
+            self.setLoginPlaceholder(placeholder: "닉네임")
+            isSecureTextEntry = false
+            rightView = righthButtonView.addButtonsInTextfield(views: [clearButton], padding: sidePadding)
         }
     }
     


### PR DESCRIPTION
# ✨작업한내용
## 1.구현결과

### 닉네임을 나중에 입력하는 경우
https://user-images.githubusercontent.com/99013115/232207249-7e081388-15ad-4fe2-842d-c829b5305beb.mov

### 닉네임을 먼저입력하는 경우

https://user-images.githubusercontent.com/99013115/232207354-de483143-90c7-4eb2-91ba-93f990076773.mov


## 2.BottomSheet구현
- 처음엔 view자체를 transform해서 올리는방식으로 만들었는데 @seungchan2 팟짱님 의도는 그게 아닌거같아서 snapkit에있는 updateconstraints를 이용해서 구현했습니다
### BottomSheet 보여지는 원리
```swift
    override func viewDidAppear(_ animated: Bool) {
        super.viewDidAppear(animated)
        showBottomSheet()
    }

    private func showBottomSheet() {
        bottomSheetView.snp.updateConstraints { $0.bottom.equalToSuperview() }
        UIView.animate(withDuration: 0.25) {
            self.backgroundView.alpha = 0.7
            self.view.layoutIfNeeded()
        }
    }
```
- 바텀시트ViewController 객체가 생성되면 life cycle중 viewdidAppear에서 bottomsheet가 나오는 함수를 실행해줍니다.

### BottomSheet 숨겨지는 원리
```swift
    private func hideButtonSheetAndDismissViewController() {
        bottomSheetView.snp.updateConstraints { $0.bottom.equalToSuperview().inset(-bottomSheetHeight) }
        UIView.animate(withDuration: 0.25) {
            self.backgroundView.alpha = 0
            self.view.layoutIfNeeded()
        } completion: { _ in
            if self.presentationController != nil {
                self.dismiss(animated: true)
            }
        }
    }
```
- 우선 bottomsheet를 sheet높이만큼 내려주고 이전 viewcontroller가 해제되지 않았다면 그때 dismiss해주는방식
- 여기서 의문이었던게 이 bottomsheet자체가 앱 아래쪽으로 내려가면 이게 안짤린상태로 있으면 메모리를 차지할까봐 sheet자체를 clipstobounds를 true로 줘서 view밖으로 나가면 자동으로 잘리게 설정을해줬습니다(근데 이건 머릿속에서 이러면 될거같다라고 생각해서 준거라 어떻게될지는 모르겠네요)

## 3.데이터전달(delgate)
- 편하게 늘쓰던방식인 delegate방식을 사용하였습니다
```swift
protocol PassingNicknameDataProtocol: AnyObject {
    func sendNickname(_ nickName: String)
}
```
- 여기서 main login vc에서 저장속성에 name을 넣어주고 이를 다음 vc로 넘겨서 띄워주는 방식입니다
- 근데 생각해보니 로그인버튼이 닉네임이 있을때만 활성화가 되어야할거같아서 해당 로직을 조금 넣었습니다
```swift
extension LoginViewController: PassingNicknameDataProtocol {
    func sendNickname(_ nickName: String) {
        guard let emailText = emailTextField.text, let passwordText = passwordTextField.text else { return }
        self.nickName = nickName
        loginButton.makeActiveTypeButton(activeType: emailText.checkEmail && passwordText.checkPassword ? .active : .nonActive)
    }
}
```
- 위 코드는 이미 email과 비밀번호를 textfield에 넣은 후 닉네임을 적었다면 button을 active상태로 만들어줍니다
- 만약에 처음부터 닉네임을 설정하고 email이나 비번을적는경우는 늘그랫듯 textfield delegate에서 처리해줍니다
```swift
extension LoginViewController: UITextFieldDelegate {
    func textFieldDidChangeSelection(_ textField: UITextField) {
        guard let text = textField.text, let tvingTextField = textField as? TvingTextField else { return }
        guard let emailText = emailTextField.text, let passwordText = passwordTextField.text else { return }
        
        tvingTextField.clearButtonClicked = text.isNotEmpty ? false : true
        loginButton.makeActiveTypeButton(activeType: emailText.checkEmail && passwordText.checkPassword && ((nickName?.isNotEmpty) != nil) ? .active : .nonActive)
    }
}
```
- 그리고 간단하게 bottomSheet에서 닉네임을 한글자라도 입력해야 버튼이 활성화 되도록 만들었습니다.
```swift
extension LoginNicknameBottomSheetViewController: UITextFieldDelegate {
    func textFieldDidChangeSelection(_ textField: UITextField) {
        guard let text = textField.text else { return }
        saveNicknameButton.makeActiveTypeButton(activeType: text.isNotEmpty ? .active : .nonActive)
    }
}
```
